### PR TITLE
chore!: drop support for Node.js 14

### DIFF
--- a/.github/workflows/verify-test.yml
+++ b/.github/workflows/verify-test.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['14', '16', '18']
+        node: ['16', '18']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['14', '16', '18']
+        node: ['16', '18']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Express/connect middleware to handle 405 errors, when a request method is not su
 
 This library requires the following to run:
 
-  * [Node.js](https://nodejs.org/) 14+
+  * [Node.js](https://nodejs.org/) 16+
 
 
 ## Usage

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "typescript": "^4.7.3"
       },
       "engines": {
-        "node": "14.x || 16.x || 18.x",
+        "node": "16.x || 18.x",
         "npm": "8.x || 9.x"
       }
     },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "bugs": "https://github.com/rowanmanning/allow-methods/issues",
   "license": "MIT",
   "engines": {
-    "node": "14.x || 16.x || 18.x",
+    "node": "16.x || 18.x",
     "npm": "8.x || 9.x"
   },
   "scripts": {


### PR DESCRIPTION
Node.js 14 is end-of-life in April 2022. This removes support.